### PR TITLE
Windows, decoupling from Play2War, eb-update-version, + extras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 target/
-
+.idea/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Add the following settings to your project:
 val main = play.Project(appName, appVersion, appDependencies).settings(
   resolvers += Resolver.url("SQS Ivy", url("http://sqs.github.com/repo"))(Resolver.ivyStylePatterns),
   Play2WarKeys.servletVersion := "3.0",
+  ebAppBundle <<= Play2WarKeys.war,
   ebS3BucketName := "some-bucket-name",
   ebDeployments := Seq(
     Deployment(

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Features
 Changelog
 ---------
 
-* 0.0.7: Windows support. Decoupled from Play to support Lift, etc.
+* 0.0.7: Windows support. Decoupled from Play to support Lift, etc. Added `eb-update-version`. Reads System properties when `~/.aws-credentials` cannot be found.
 * 0.0.6: Better, template-aware `eb-config-push` and `eb-config-pull`; added `eb-quick-update`
 * 0.0.5: Add configuration pushing `eb-config-push` and validation `eb-local-config-validate`.
 * 0.0.4: Add configuration pulling `eb-config-pull`; add `eb-wait` to wait until deployed; add `eb-api-describe-applications`, `eb-api-describe-environments`, and `eb-api-restart-app-server` tasks.

--- a/README.md
+++ b/README.md
@@ -60,13 +60,20 @@ val main = play.Project(appName, appVersion, appDependencies).settings(
 
 You must create the S3 bucket and Elastic Beanstalk app and environment specified in this file. You can specify your preferred AWS region.
 
-Create a file in `$HOME/.aws-credentials` with your AWS credentials in the following format:
+Either create a file in `$HOME/.aws-credentials` with your AWS credentials in the following format:
 
 ```
 accessKey = <your AWS access key>
 secretKey = <your AWS secret key>
 ```
 
+... or pass these two values as properties to `sbt`:
+
+```
+sbt -DaccessKey=your_AWS_access_key -DsecretKey=your_AWS_secret_key
+```
+
+Note that the `.aws-credentials` file takes precedence over the `System` properties.
 
 Configuration for non-Play
 -------------

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ ebDeployments := Seq(
 )
 
 ebRegion := "us-west-1"
+```
 
 You must create the S3 bucket and Elastic Beanstalk app and environment specified in this file. You can specify your preferred AWS region.  Note that this assumes the web application plugin you are utilizing produces a war file with the compile:package key.  This is the case for Lift, for instance.  
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ Changelog
 * 0.0.2: Added support for deployment to multiple apps and environments
 * 0.0.1: Initial release
 
+Contributors
+------------
+Quinn Slack ([sqs])
+Joe Barnes ([barnesjd])
+
 
 License
 -------
@@ -174,3 +179,6 @@ This code is open source software licensed under the [Apache 2.0 License][apache
 [apache2]: http://www.apache.org/licenses/LICENSE-2.0.html
 [awseb]: http://aws.amazon.com/elasticbeanstalk/
 [play2war]: https://github.com/dlecan/play2-war-plugin
+
+[sqs]: https://github.com/sqs
+[barnesjd]: https://github.com/barnesjd

--- a/core/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/core/AWS.scala
+++ b/core/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/core/AWS.scala
@@ -5,13 +5,10 @@ import com.amazonaws.services.ec2.AmazonEC2Client
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClient
 import com.amazonaws.services.s3.AmazonS3Client
 import java.io.File
-import scala.sys.SystemProperties
 
 object AWS {
-  lazy val props = new SystemProperties()
-  
   lazy val awsCredentials = {
-    val file = new File(new File(props("user.home")), ".aws-credentials")
+    val file = new File(new File(System.getProperty("user.home")), ".aws-credentials")
     if (!file.exists) {
       throw new Exception("AWS credentials file not found at " + file.getAbsolutePath + "\n\n" +
                           "Create a file at that path with the following contents:\n\n" +

--- a/core/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/core/AWS.scala
+++ b/core/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/core/AWS.scala
@@ -5,10 +5,13 @@ import com.amazonaws.services.ec2.AmazonEC2Client
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClient
 import com.amazonaws.services.s3.AmazonS3Client
 import java.io.File
+import scala.sys.SystemProperties
 
 object AWS {
+  lazy val props = new SystemProperties()
+  
   lazy val awsCredentials = {
-    val file = new File(new File(System.getenv("HOME")), ".aws-credentials")
+    val file = new File(new File(props("user.home")), ".aws-credentials")
     if (!file.exists) {
       throw new Exception("AWS credentials file not found at " + file.getAbsolutePath + "\n\n" +
                           "Create a file at that path with the following contents:\n\n" +
@@ -17,7 +20,7 @@ object AWS {
     }
     new PropertiesCredentials(file)
   }
-
+  
   def ec2Client(region: String): AmazonEC2Client = {
     val c = new AmazonEC2Client(awsCredentials)
     c.setEndpoint("https://ec2." + region + ".amazonaws.com")

--- a/core/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/core/SourceBundleUploader.scala
+++ b/core/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/core/SourceBundleUploader.scala
@@ -18,7 +18,7 @@ class SourceBundleUploader(
 
   // TODO: make async
   def upload(): S3Location = {
-    val key = bundleFile.getName + "-" + System.getenv("USER") + "-" + dateFormatter.format(new Date)
+    val key = bundleFile.getName + "-" + System.getProperty("user.name") + "-" + dateFormatter.format(new Date)
 
     val tx = new TransferManager(awsCredentials)
 

--- a/core/src/test/scala/com/blendlabsinc/sbtelasticbeanstalk/core/SourceBundleUploaderSpec.scala
+++ b/core/src/test/scala/com/blendlabsinc/sbtelasticbeanstalk/core/SourceBundleUploaderSpec.scala
@@ -9,6 +9,6 @@ class SourceBundleUploaderSpec extends FunSpec with ShouldMatchers {
     val s3Location = u.upload()
     s3Location.getS3Bucket should equal (TestCommon.s3BucketName)
     s3Location.getS3Key should include (TestCommon.warName)
-    s3Location.getS3Key should include (System.getenv("USER"))
+    s3Location.getS3Key should include (System.getProperty("user.name"))
   }
 }

--- a/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Commands.scala
+++ b/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Commands.scala
@@ -85,7 +85,7 @@ trait ElasticBeanstalkCommands {
             .withApplicationName(appName)
             .withVersionLabel(versionLabel)
             .withSourceBundle(sourceBundle)
-            .withDescription("Deployed by " + System.getenv("USER"))
+            .withDescription("Deployed by " + System.getProperty("user.name"))
         ).getApplicationVersion
       }.toMap
 

--- a/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Keys.scala
+++ b/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Keys.scala
@@ -34,6 +34,7 @@ object ElasticBeanstalkKeys {
 
   val ebDeploy = TaskKey[Unit]("eb-deploy", "Deploy the application WAR to Elastic Beanstalk")
   val ebQuickUpdate = InputKey[Unit]("eb-quick-update", "Update the application WAR in-place on a running server.")
+  val ebCreateVersion = TaskKey[Map[Deployment,EnvironmentDescription]]("eb-create-version", "Creates a new application version in the configured environment.")
   val ebWait = TaskKey[Unit]("eb-wait", "Wait for all project environments to be Ready and Green")
 
   val ebSetUpEnvForAppVersion = TaskKey[Map[Deployment,EnvironmentDescription]]("eb-setup-env-for-app-version", "Sets up a new environment for the WAR file.")

--- a/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Keys.scala
+++ b/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Keys.scala
@@ -34,7 +34,9 @@ object ElasticBeanstalkKeys {
 
   val ebDeploy = TaskKey[Unit]("eb-deploy", "Deploy the application WAR to Elastic Beanstalk")
   val ebQuickUpdate = InputKey[Unit]("eb-quick-update", "Update the application WAR in-place on a running server.")
-  val ebCreateVersion = TaskKey[Map[Deployment,EnvironmentDescription]]("eb-create-version", "Creates a new application version in the configured environment.")
+  val ebCreateVersion = TaskKey[Map[String,ApplicationVersionDescription]]("eb-create-version", "Creates a new application version in the configured environment.")
+  // TODO: Determine if this task has the same intent as ebQuickUpdate
+  val ebUpdateVersion = TaskKey[Map[Deployment, EnvironmentDescription]]("eb-update-version", "Uploads a new application version and updates the configured environment with the version.")
   val ebWait = TaskKey[Unit]("eb-wait", "Wait for all project environments to be Ready and Green")
 
   val ebSetUpEnvForAppVersion = TaskKey[Map[Deployment,EnvironmentDescription]]("eb-setup-env-for-app-version", "Sets up a new environment for the WAR file.")

--- a/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Settings.scala
+++ b/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Settings.scala
@@ -2,7 +2,6 @@ package com.blendlabsinc.sbtelasticbeanstalk
 
 import com.blendlabsinc.sbtelasticbeanstalk.core.AWS
 import com.blendlabsinc.sbtelasticbeanstalk.ElasticBeanstalkKeys._
-import com.github.play2war.plugin.Play2WarKeys
 import sbt.{ Setting, Hash }
 import sbt.Keys.{ baseDirectory, commands }
 
@@ -11,7 +10,6 @@ trait ElasticBeanstalkSettings {
 
   val sessionId = new java.math.BigInteger(130, new java.security.SecureRandom()).toString(32) // HACK TODO
   lazy val elasticBeanstalkSettings = Seq[Setting[_]](
-    ebAppBundle <<= Play2WarKeys.war,
     ebEnvironmentNameSuffix := { (name) =>
       val maxLen = 23
       val uniq = sessionId

--- a/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Settings.scala
+++ b/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Settings.scala
@@ -17,6 +17,7 @@ trait ElasticBeanstalkSettings {
       name + "-" + System.getProperty("user.name").take(3) + uniq.take(3)
     },
     ebDeploy <<= ebDeployTask,
+    ebCreateVersion <<= ebCreateVersionTask,
     ebQuickUpdate <<= ebQuickUpdateTask,
     ebSetUpEnvForAppVersion <<= ebSetUpEnvForAppVersionTask,
     ebWait <<= ebWaitForEnvironmentsTask,

--- a/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Settings.scala
+++ b/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Settings.scala
@@ -14,7 +14,7 @@ trait ElasticBeanstalkSettings {
       val maxLen = 23
       val uniq = sessionId
       if (name.length > (23 - 7)) throw new Exception("environment name too long: " + name)
-      name + "-" + System.getenv("USER").take(3) + uniq.take(3)
+      name + "-" + System.getProperty("user.name").take(3) + uniq.take(3)
     },
     ebDeploy <<= ebDeployTask,
     ebQuickUpdate <<= ebQuickUpdateTask,

--- a/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Settings.scala
+++ b/plugin/src/main/scala/com/blendlabsinc/sbtelasticbeanstalk/Settings.scala
@@ -18,6 +18,7 @@ trait ElasticBeanstalkSettings {
     },
     ebDeploy <<= ebDeployTask,
     ebCreateVersion <<= ebCreateVersionTask,
+    ebUpdateVersion <<= ebUpdateVersionTask,
     ebQuickUpdate <<= ebQuickUpdateTask,
     ebSetUpEnvForAppVersion <<= ebSetUpEnvForAppVersionTask,
     ebWait <<= ebWaitForEnvironmentsTask,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -36,14 +36,13 @@ object Build extends Build {
       "com.fasterxml.jackson.core" % "jackson-core" % "2.1.1",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.1.1",
       "net.schmizz" % "sshj" % "0.8.1",
-      "org.bouncycastle" % "bcprov-jdk16" % "1.46",
-      "com.github.play2war" % "play2-war-plugin" % "0.9a-SNAPSHOT" % "provided->default(compile)" extra ("scalaVersion" -> "2.9.2", "sbtVersion" -> "0.12")
+      "org.bouncycastle" % "bcprov-jdk16" % "1.46" 
     )
   ).dependsOn(sbtElasticBeanstalkCore).aggregate(sbtElasticBeanstalkCore)
 
   def commonSettings = Defaults.defaultSettings ++ Seq(
     organization := "com.blendlabsinc",
-    version := "0.0.6-SNAPSHOT",
+    version := "0.0.7-SNAPSHOT",
     scalaVersion := "2.9.2",
     scalacOptions ++= Seq("-unchecked", "-deprecation"),
     publishMavenStyle := false,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.1
+sbt.version=0.12.4

--- a/sample-Play2-app/project/Build.scala
+++ b/sample-Play2-app/project/Build.scala
@@ -14,6 +14,7 @@ object ApplicationBuild extends Build {
   val main = play.Project(appName, appVersion, appDependencies).settings(
     resolvers += Resolver.url("SQS Ivy", url("http://sqs.github.com/repo"))(Resolver.ivyStylePatterns),
     Play2WarKeys.servletVersion := "3.0",
+    ebAppBundle <<= Play2WarKeys.war,
     ebS3BucketName := "sbt-elasticbeanstalk-test",
     ebDeployments := Seq(
       Deployment(

--- a/sample-Play2-app/project/plugins.sbt
+++ b/sample-Play2-app/project/plugins.sbt
@@ -10,4 +10,4 @@ resolvers += Resolver.url("SQS Ivy", url("http://sqs.github.com/repo"))(Resolver
 
 // resolvers += Resolver.file("Local Ivy", file(Path.userHome + "/.ivy2/local"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.blendlabsinc" % "sbt-elasticbeanstalk-plugin" % "0.0.6-SNAPSHOT")
+addSbtPlugin("com.blendlabsinc" % "sbt-elasticbeanstalk-plugin" % "0.0.7-SNAPSHOT")


### PR DESCRIPTION
Quinn,

I have a pull request for ya!  First off, great job creating a handy sbt plugin!  I found it to be 98% of what I needed.  This pull request contains the tweaks I needed for our use case.  Here's a breakdown of what I did:
## Added support for Windows

There were several usages of `System.getenv(String)` which retrieves info available to the standard unix environment.  I changed these out for `System.getProperty(String)` to retrieve the JVM-provided equivalent information.  Now the plugin works great for us unfortunate souls who are shackled to the vile MS corporation.
## Removed hard dependency on Play2War

Our team uses Lift, so the coupling to `Play2War` prevented use from using the plugin out of the box.  I have updated the code base to no longer depend directly on `Play2War`.  The benefit is now _any_ war-producing framework can utilize this plugin.  The cost is any current users wishing to upgrade to this version now must tell the plugin what task produces the war file.  In particular, this line must now be added to the build file:

```
ebAppBundle <<= Play2WarKeys.war,
```

I like it because it helps make this plugin useful to a broader user base, and I hope it's an acceptable change for your current users.
## Added eb-update-version

This is possibly a duplicate of `eb-quick-update`, at least in its intent.  The `eb-quick-update` didn't work for us because it needs to connect to our EC2 instance via SSH.  Our network architecture doesn't easily allow us that access.  Instead, it is much more straight-forward to utilize the AWS API to tell Elastic Beanstalk to deploy the newly-uploaded application version.  Our use case is continuous integration.  The downtime is acceptable.  
## Reads from System properties when ~/.aws-credentials cannot be found

Also due to our use case of continuous integration, our build process runs on a VM with an automated user.  Hence it doesn't make sense for us to find all VMs our build _might_ run on and include an `.aws-credentials` file.  Passing the credentials as properties via the command-line is a much more reasonable approach.  The plugin still first checks for the existence of an `.aws-credentials` file.  In the case one isn't found, the fallback first looks at `System` properties for `accessKey` and `secretKey`.  The error message has been updated accordingly.
## Updated readme to show how to utilize with Play2War OR Lift

Finally I updated the readme to reflect the usage of the plugin with Play or other non-Play frameworks.  For the latter, I also wrote it in `.sbt` format as a second example of how the plugin can be configured.  Other changes such as the aws-credentials properties and Changelog have been updated appropriately.

I hope you find these changes suitable for a merge for general consumption.  Let me know if I should make any changes to my contributions.

Again, thanks for putting your hard work out here for others to take advantage of!

**Joe Barnes**
Senior Software Architect
System Design Division
Mentor Graphics
